### PR TITLE
fix: Example pull_request_target: is wrong and very badly broken

### DIFF
--- a/dependents/source_repo.yml
+++ b/dependents/source_repo.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - 'main'
   delete:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
see https://github.com/www-learn-study/saraswati.learn.study/pull/47

If you use pull_request_target: instead of pull_request: then the `actions/checkout`, at least in v4.1.1, will always check out the default branch, not the pull request.